### PR TITLE
[RFR] StackStorm 2.1 compatibility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,13 @@
 # Change Log
 
+# 0.3.0
+
+- Use `packs.install` capabilities in StackStorm 2.1
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.
 
 # 0.1.0
 
-- First release 
+- First release

--- a/README.md
+++ b/README.md
@@ -194,16 +194,10 @@ st2 run bitbucket.list_branches repo="<repo_name>"
 
 ### Post-Receive WebHook
 
-This rule triggers ``packs.deploy`` action (in StackStorm v1.4+) to allow
-auto-deployment of single pack repository.
+This rule triggers ``packs.install`` action (in StackStorm v2.1+) to allow
+auto-deployment of a pack from a git repository.
 
-This has a number of pre-dependancies:
-
-- The repository being configured in:
-
-```bash
-/opt/stackstorm/packs/packs/config.yaml
-```
+This has a number of pre-dependencies:
 
 - Setting Workflow / Hooks / Post-Receive WebHooks pointing at the URL:
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,9 @@ keywords:
   - mercurial
   - git
   - source control
-version: 0.1.1
+version: 0.3.0
+stackstorm_version: ">=2.1.0"
 author: Aamir
 email: raza.aamir01@gmail.com
+contributors:
+  - Edward Medvedev <edward.medvedev@gmail.com>

--- a/rules/post_receive_webhook.yaml
+++ b/rules/post_receive_webhook.yaml
@@ -15,11 +15,7 @@ criteria:
     type: "exists"
 
 action:
-  ref: "packs.deploy"
+  ref: "packs.install"
   parameters:
-    auto_deploy: true
-    repo_name:  "{{trigger.body.repository.name}}"
-    branch:     "{{trigger.body.refChanges[0].refId}}"
-    packs:      [ "{{trigger.body.repository.name}}" ]
-    message:    "{{trigger.body.changesets.get('values')[0].toCommit.message}}"
-    author:     "{{trigger.body.changesets.get('values')[0].toCommit.author.name}}"
+    packs:
+      - "https://bitbucket.org/{{trigger.body.repository.full_name}}={{trigger.body.refChanges[0].refId}}"


### PR DESCRIPTION
**Do not merge until the Exchange transition is finalized**

This is similar to the github pack PR: https://github.com/StackStorm-Exchange/stackstorm-github/pull/1. 

New `packs.install` from StackStorm 2.1 allows us to download packs by git URLs and specify branches/tags/sha with a single parameter. Let’s make use of it and simplify the `post_receive_webhook` rule.