### PR TITLE
Corrected RepositorySensor to dispatch trigger about update commits by the set of (repository, branch)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.5.1
+
+- Corrected RepositorySensor to dispatch trigger about update commits by the set of (repository, branch)
+
 # 0.5.0
 
 - Added sensor to monitor events of specified repositories in the BitBucket Cloud or specified BitBucket Server

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,7 +8,7 @@ keywords:
   - mercurial
   - git
   - source control
-version: 0.5.0
+version: 0.5.1
 stackstorm_version: ">=2.1.0"
 author: Aamir
 email: raza.aamir01@gmail.com

--- a/sensors/repository_sensor.py
+++ b/sensors/repository_sensor.py
@@ -132,8 +132,16 @@ class RepositorySensor(PollingSensor):
             # update last_commit instance variable
             self._update_last_commit()
 
-            # dispatch new commit informatoins
-            self._dispatch_trigger('commit', self.new_commits)
+            # dispatch new commit informatoins every repository/branch
+            for (repo, branch) in set([(x['repository'], x['branch']) for x in self.new_commits]):
+                payload = {
+                    'repository': repo,
+                    'branch': branch,
+                    'commits': [x for x in self.new_commits if (x['repository'] == repo and
+                                                                x['branch'] == branch)],
+                }
+
+                self._dispatch_trigger('commit', payload)
 
     def cleanup(self):
         pass

--- a/sensors/repository_sensor.yaml
+++ b/sensors/repository_sensor.yaml
@@ -17,4 +17,4 @@ trigger_types:
         type:
           type: "string"
         payload:
-          type: "array"
+          type: "object"


### PR DESCRIPTION
## Abstraction
The current implementation has a problem to set 'criteria' in the rule.
By this patch, we can set a condition to identify target repository or branch in the `criteria` parameter in the Rule. 

## Background / Problem
The current payload type of `repository_event` Trigger is `array` which includes commit information as dict as follows.
```
[
  {'msg': u'test commit message1', 'author': u'user.localhost2000@gmail.com', 'repository': u'group/test-repo', 'branch': u'master', 'time': '2017-07-24 17:31:02'},
  {'msg': u'test commit message2', 'author': u'user.localhost2000@gmail.com', 'repository': u'group/test-repo', 'branch': u'master', 'time': '2017-07-24 17:33:04'},
  {'msg': u'test commit message3', 'author': u'user.localhost2000@gmail.com', 'repository': u'group/test-repo', 'branch': u'dev', 'time': '2017-07-24 17:32:36'}
]
```
In this case, we can't write a condition to detect a specific Repository or Branch in the `criteria` parameter of Rule. Because there is no [operator](https://docs.stackstorm.com/rules.html#critera-comparison) to match `array of dicts` value.

## Solution
There are two ways to solve this problem, I guess.
- Changing to decouple trigger-payload by each (repository, branch) set.
- Adding a new operator to match `array of dicts` value.

I think former is reasonable because 
- it's rare to handle commits of whole repositories and branches in an action.
- it's easy to change.