### PR TITLE
Appending change_files parameter which describes changed files in the updated commits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# 0.5.3
+
+- Added a parameter `changed_files` on the dispatching payload to enable to identify the changed files in the updated commits.
+  (But this parameter is only set for the repository on the BitBucket server)
+
 # 0.5.2
 
 - Changed configuration schema to allow specifying branch to monitor for each repository. You will need to update your configuration.

--- a/README.md
+++ b/README.md
@@ -210,20 +210,25 @@ Currently, this supports following event type.
 Here is an example of trigger payload:
 ```
 {
-  "repository": "xaas/deploy-test",
-  "branch": "master",
-  "changed_files": {"deleted": [], "added": [], "moved": [], "modified": ["foo/bar", u"hoge/fuga/tmp01"]},
-  "commits": [
-    {
-      "msg": "updated README to add the description for the function-A",
-      "author": "user.localhost2000@gmail.com",
-      "repository": "XAAS/deploy-test",
-      "branch": "master",
-      "time": "'2017-06-24 08:17:26'"
-      "files": {"deleted": [], "added": [], "moved": [], "modified": ["foo/bar"]},
-    },
-    ...
-  ]
+  "id": "25",
+  "created_at": "2017-09-29 03:19:50",
+  "type": "commit",
+  "payload": {
+    "repository": "xaas/deploy-test",
+    "branch": "master",
+    "changed_files": {"deleted": [], "added": [], "moved": [], "modified": ["foo/bar", u"hoge/fuga/tmp01"]},
+    "commits": [
+      {
+        "msg": "A test commit message",
+        "author": "user.localhost2000@gmail.com",
+        "repository": "XAAS/deploy-test",
+        "branch": "master",
+        "time": "2017-09-29 03:19:36",
+        "files": {"deleted": [], "added": [], "moved": [], "modified": ["foo/bar"]},
+      },
+      ...
+    ]
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -209,16 +209,25 @@ Currently, this supports following event type.
 
 Here is an example of trigger payload:
 ```
-[
-  {
-    "msg": "updated README to add the description for the function-A",
-    "author": "user.localhost2000@gmail.com",
-    "repository": "XAAS/deploy-test",
-    "branch": "master",
-    "time": "'2017-06-24 08:17:26'"
-  }
-]
+{
+  "repository": "xaas/deploy-test",
+  "branch": "master",
+  "changed_files": {"deleted": [], "added": [], "moved": [], "modified": ["foo/bar", u"hoge/fuga/tmp01"]},
+  "commits": [
+    {
+      "msg": "updated README to add the description for the function-A",
+      "author": "user.localhost2000@gmail.com",
+      "repository": "XAAS/deploy-test",
+      "branch": "master",
+      "time": "'2017-06-24 08:17:26'"
+      "files": {"deleted": [], "added": [], "moved": [], "modified": ["foo/bar"]},
+    },
+    ...
+  ]
+}
 ```
+
+*restriction* The `files` and `changed_files` parameters are not set in the Bitbucket cloud (The feature is not implemented, yet)
 
 ## Rules
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,7 +8,7 @@ keywords:
   - mercurial
   - git
   - source control
-version: 0.5.2
+version: 0.5.3
 stackstorm_version: ">=2.1.0"
 author: Aamir
 email: raza.aamir01@gmail.com

--- a/sensors/repository_sensor.py
+++ b/sensors/repository_sensor.py
@@ -87,7 +87,8 @@ class RepositorySensor(PollingSensor):
                 This returns file-pathes which are changed in this commit.
                 """
                 def do_get_updated_files(req_type):
-                    return [x['path']['toString'] for x in commit['values'] if x['type'] == req_type]
+                    return [x['path']['toString'] for x in commit['values']
+                            if x['type'] == req_type]
 
                 return {
                     'added': do_get_updated_files('ADD'),
@@ -207,8 +208,8 @@ class RepositorySensor(PollingSensor):
                 # This processing enables to make a more complex criteria in the Rule
                 for t in ['added', 'moved', 'deleted', 'modified']:
                     # Tally up the all changed-files
-                    payload['changed_files'][t] += \
-                            sum([x['files'][t] for x in self.new_commits if t in x['files']], [])
+                    payload['changed_files'][t] += sum([x['files'][t] for x in self.new_commits
+                                                        if t in x['files']], [])
 
                     # De-duplicate each changed-files
                     payload['changed_files'][t] = list(set(payload['changed_files'][t]))

--- a/sensors/repository_sensor.yaml
+++ b/sensors/repository_sensor.yaml
@@ -18,3 +18,26 @@ trigger_types:
           type: "string"
         payload:
           type: "object"
+          properties:
+            commits:
+              type: "array"
+              items: "object"
+            repository:
+              type: "string"
+            branch:
+              type: "string"
+            changed_files:
+              type: "object"
+              properties:
+                added:
+                  type: "array"
+                  items: "string"
+                moved:
+                  type: "array"
+                  items: "string"
+                modified:
+                  type: "array"
+                  items: "string"
+                deleted:
+                  type: "array"
+                  items: "string"


### PR DESCRIPTION
This is the change for #11.

The main points of this change are following.

* Appending new parameter `changed_files` which describes manipulated files within the updated commits for each operation type 'add', 'delete', 'moved', 'modified' to the dispaching payload.
  But currently this feature is workable only with the BitBucket Server. I should be able to implement equivalent feature for the BitBucket cloud.

* Correcting the payload format which is written in the README. Previously, the only `commits` parameter value which is a parameter of dispatching payload was described in the README. Then, I corrected it to describe whole payload format and added new parameters `changed_files` and `files`.
  The `files` is the parameter which describes manipulated files in the target commit. And `changed_files` means the all manipulated files within the whole updated commits by omitting the overlapping.

Thank you.
