### PR TITLE
hotfix/fix-ci-errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 1.0.3
+
+* Updated files to work with latest CI updates
+
 # 1.0.2
 
 * Bug fix: python3 syntax fix

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,7 +8,7 @@ keywords:
   - mercurial
   - git
   - source control
-version: 1.0.2
+version: 1.0.3
 stackstorm_version: ">=2.1.0"
 author: Aamir
 email: raza.aamir01@gmail.com

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,0 +1,2 @@
+stashy==0.3
+pybitbucket==0.12.0

--- a/tests/test_repository_sensor.py
+++ b/tests/test_repository_sensor.py
@@ -1,4 +1,4 @@
-import collections
+from collections.abc import Iterator
 import mock
 import stashy
 import time
@@ -212,7 +212,7 @@ class RepositorySensorTestCase(BaseSensorTestCase):
         self.assertTrue(all([x in commit_info for x in commit_keys]))
 
 
-class MockCommits(collections.Iterator):
+class MockCommits(Iterator):
     def __init__(self, count, author, commit_model):
         self.delay = None
         self.commits = []


### PR DESCRIPTION
Fixed files to work with latest CI updates:

- `Iterator` was moved from `collections` to `collections.abc` in Python 3.3 and deprecated in 3.10
https://stackoverflow.com/a/72330128
https://docs.python.org/3/library/collections.abc.html